### PR TITLE
Restyle landing experience to match new design

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,36 +1,5 @@
-import Link from "next/link";
-import styles from "./page.module.css";
+import { redirect } from "next/navigation";
 
 export default function Home() {
-  return (
-    <section className={styles.hero}>
-      <div className={styles.copy}>
-        <h1>Can You Makeup</h1>
-        <p>
-          Scopri nuovi prodotti con una meccanica swipe veloce: scegli il tier, acquista il biglietto
-          e prova a completare il carrello prima che il tempo scada.
-        </p>
-        <div className={styles.actions}>
-          <Link href="/play" className="btn">
-            Inizia a giocare
-          </Link>
-          <Link href="/settings" className="btn secondary">
-            Gestisci settori
-          </Link>
-        </div>
-      </div>
-      <div className={styles.preview}>
-        <div className={styles.previewCard}>
-          <span className={styles.previewBadge}>Occhi</span>
-          <h3>Mascara Aurora</h3>
-          <p>Curvatura estrema in un solo swipe. Formula waterproof con finish glossy.</p>
-          <div className={styles.previewPrice}>29,90€</div>
-        </div>
-        <div className={styles.floatingActions}>
-          <span className={styles.reject}>✕</span>
-          <span className={styles.like}>❤</span>
-        </div>
-      </div>
-    </section>
-  );
+  redirect("/play");
 }

--- a/app/play/page.module.css
+++ b/app/play/page.module.css
@@ -1,46 +1,78 @@
 .page {
-  min-height: calc(100vh - 160px);
+  min-height: calc(100vh - 140px);
+  width: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: clamp(1.5rem, 4vw, 3.5rem) clamp(1rem, 4vw, 3rem) clamp(3rem, 6vw, 4rem);
+  padding: clamp(2rem, 5vw, 4rem);
   position: relative;
+  isolation: isolate;
+  overflow: hidden;
+}
+
+.page::before,
+.page::after {
+  content: "";
+  position: absolute;
+  z-index: 0;
+  width: clamp(280px, 45vw, 520px);
+  height: clamp(280px, 45vw, 520px);
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 184, 212, 0.35) 0%, rgba(255, 255, 255, 0) 72%);
+  filter: blur(0px);
+}
+
+.page::before {
+  top: -120px;
+  left: -140px;
+}
+
+.page::after {
+  bottom: -160px;
+  right: -120px;
+}
+
+.page > * {
+  position: relative;
+  z-index: 1;
 }
 
 .loader {
   text-align: center;
   font-weight: 500;
-  color: #b10059;
+  color: #ff5e86;
 }
 
 .timer {
   display: inline-flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.5rem 0.75rem;
+  gap: 0.9rem;
+  padding: 0.65rem 1rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.85);
-  box-shadow: 0 15px 45px rgba(20, 30, 55, 0.12);
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(255, 149, 190, 0.28);
+  box-shadow: 0 18px 45px rgba(20, 30, 55, 0.15);
+  backdrop-filter: blur(16px);
 }
 
 .timerTrack {
-  width: clamp(140px, 25vw, 240px);
-  height: 0.5rem;
+  width: clamp(160px, 28vw, 260px);
+  height: 0.55rem;
   border-radius: 999px;
-  background: rgba(255, 174, 215, 0.28);
+  background: rgba(255, 182, 212, 0.3);
   overflow: hidden;
 }
 
 .timerFill {
   height: 100%;
   border-radius: inherit;
-  background: linear-gradient(135deg, #ff7cb4 0%, #ff9a8d 100%);
+  background: linear-gradient(135deg, #ff6b88 0%, #ff9d6f 100%);
   transition: width 0.35s ease;
 }
 
 .timerLabel {
-  font-weight: 600;
-  color: #b10059;
+  font-weight: 700;
+  color: #ff5e86;
 }
 
 .toast {
@@ -51,11 +83,11 @@
   display: inline-flex;
   align-items: center;
   gap: 0.75rem;
-  padding: 0.9rem 1.1rem;
+  padding: 0.95rem 1.25rem;
   border-radius: 999px;
-  background: rgba(17, 24, 39, 0.85);
+  background: rgba(17, 24, 39, 0.82);
   color: white;
-  box-shadow: 0 18px 45px rgba(17, 24, 39, 0.3);
+  box-shadow: 0 18px 45px rgba(17, 24, 39, 0.35);
   z-index: 40;
 }
 
@@ -76,41 +108,46 @@
 
 .stepCard {
   width: min(640px, 100%);
-  background: rgba(255, 255, 255, 0.94);
-  border-radius: 28px;
-  box-shadow: 0 28px 80px rgba(20, 30, 55, 0.18);
-  padding: clamp(2rem, 4vw, 3.25rem);
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.92), rgba(255, 214, 232, 0.82));
+  border-radius: 32px;
+  border: 1px solid rgba(255, 149, 190, 0.25);
+  box-shadow: 0 30px 80px rgba(255, 149, 190, 0.26);
+  padding: clamp(2.2rem, 5vw, 3.4rem);
   display: flex;
   flex-direction: column;
-  gap: 1.4rem;
+  gap: 1.6rem;
   text-align: center;
+  backdrop-filter: blur(12px);
 }
 
 .introTitle {
-  font-size: clamp(2.4rem, 6vw, 3.2rem);
-  font-weight: 700;
-  color: #b10059;
   margin: 0;
-  letter-spacing: -0.02em;
+  font-size: clamp(2.6rem, 6vw, 3.4rem);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #ff5e86;
 }
 
 .introCopy {
   margin: 0;
-  font-size: clamp(1rem, 2.6vw, 1.25rem);
-  color: rgba(17, 24, 39, 0.74);
+  font-size: clamp(1.05rem, 2.6vw, 1.3rem);
+  color: rgba(17, 24, 39, 0.72);
+  max-width: 38ch;
+  align-self: center;
 }
 
 .glowButton {
   align-self: center;
   border: none;
   border-radius: 999px;
-  padding: 0.9rem 2.6rem;
+  padding: 1rem 3.1rem;
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
   color: white;
-  background: radial-gradient(circle at 50% 20%, #ffe6f3 0%, #ff7cb4 38%, #b10059 100%);
-  box-shadow: 0 25px 70px rgba(177, 0, 89, 0.35), 0 0 25px rgba(255, 255, 255, 0.8);
+  background: linear-gradient(135deg, #ff6b88 0%, #ff8c6f 45%, #ffce8d 100%);
+  box-shadow: 0 28px 75px rgba(255, 128, 170, 0.45), 0 0 28px rgba(255, 255, 255, 0.8);
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
@@ -124,32 +161,34 @@
 .glowButton:hover:not(:disabled),
 .glowButton:focus-visible:not(:disabled) {
   transform: translateY(-2px) scale(1.01);
-  box-shadow: 0 28px 75px rgba(177, 0, 89, 0.42), 0 0 32px rgba(255, 255, 255, 0.9);
+  box-shadow: 0 32px 82px rgba(255, 128, 170, 0.55), 0 0 34px rgba(255, 255, 255, 0.9);
 }
 
 .stepTitle {
   margin: 0;
-  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  font-size: clamp(1.9rem, 3.2vw, 2.5rem);
   font-weight: 700;
-  color: #b10059;
+  color: #ff5e86;
 }
 
 .stepSubtitle {
   margin: 0;
-  color: rgba(17, 24, 39, 0.7);
+  color: rgba(17, 24, 39, 0.72);
   font-size: 1.05rem;
 }
 
 .ticketGrid {
   display: grid;
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 1.2rem;
 }
 
 .ticketCard {
-  background: rgba(255, 255, 255, 0.88);
-  border-radius: 20px;
-  border: 1px solid rgba(177, 0, 89, 0.12);
+  background: rgba(255, 255, 255, 0.78);
+  border-radius: 24px;
+  border: 1px solid rgba(255, 149, 190, 0.22);
   overflow: hidden;
+  box-shadow: 0 20px 45px rgba(255, 149, 190, 0.18);
 }
 
 .ticketCard summary {
@@ -165,94 +204,97 @@
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  padding: 1.2rem 1.5rem;
-  background: linear-gradient(135deg, rgba(255, 124, 180, 0.15), rgba(255, 154, 141, 0.18));
-  color: #b10059;
+  padding: 1.35rem 1.7rem;
+  background: linear-gradient(140deg, rgba(255, 182, 212, 0.26), rgba(255, 214, 232, 0.32));
+  color: #ff5e86;
   font-weight: 600;
-  font-size: 1.15rem;
+  font-size: 1.18rem;
   cursor: pointer;
 }
 
 .ticketSummary:focus-visible {
-  outline: 2px solid rgba(177, 0, 89, 0.32);
+  outline: 2px solid rgba(255, 149, 190, 0.35);
   outline-offset: 4px;
 }
 
 .ticketBody {
-  padding: 1.2rem 1.5rem 1.5rem;
+  padding: 1.4rem 1.7rem 1.75rem;
   text-align: left;
   font-size: 0.95rem;
-  color: rgba(17, 24, 39, 0.7);
+  color: rgba(17, 24, 39, 0.72);
   display: grid;
-  gap: 0.5rem;
+  gap: 0.65rem;
+  background: rgba(255, 255, 255, 0.78);
 }
 
 .ticketBody button {
   justify-self: start;
   border: none;
   border-radius: 999px;
-  padding: 0.6rem 1.3rem;
-  background: rgba(177, 0, 89, 0.18);
-  color: #b10059;
+  padding: 0.65rem 1.5rem;
+  background: rgba(255, 149, 190, 0.18);
+  color: #ff5e86;
   font-weight: 600;
   cursor: pointer;
-  transition: transform 0.2s ease;
+  transition: transform 0.2s ease, background 0.2s ease;
 }
 
 .ticketBody button:hover,
 .ticketBody button:focus-visible {
   transform: translateY(-2px);
+  background: rgba(255, 149, 190, 0.26);
 }
 
 .ticketPrice {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .ticketTime {
   font-size: 0.95rem;
   color: rgba(17, 24, 39, 0.65);
+  letter-spacing: 0.02em;
 }
 
 .ticketBadge {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.4rem 0.75rem;
+  padding: 0.45rem 0.85rem;
   border-radius: 999px;
-  background: rgba(177, 0, 89, 0.12);
-  color: #b10059;
+  background: rgba(58, 199, 165, 0.16);
+  color: #1f8a71;
   font-weight: 600;
   font-size: 0.85rem;
 }
 
 .countdownCircle {
-  width: clamp(160px, 35vw, 220px);
-  height: clamp(160px, 35vw, 220px);
+  width: clamp(180px, 38vw, 240px);
+  height: clamp(180px, 38vw, 240px);
   border-radius: 50%;
-  background: radial-gradient(circle at 50% 35%, #ffe6f3, #ff7cb4 65%, #b10059 100%);
+  background: radial-gradient(circle at 50% 35%, #ffe6f3 0%, #ff7cb4 60%, #ff5e86 100%);
   display: grid;
   place-items: center;
   color: white;
   font-weight: 700;
-  font-size: clamp(2.5rem, 10vw, 4rem);
+  font-size: clamp(2.8rem, 11vw, 4.1rem);
   margin: 1rem auto 0;
-  animation: pulse 1s ease-in-out infinite;
-}
-
-@keyframes pulse {
-  0%,
-  100% {
-    transform: scale(1);
-  }
-  50% {
-    transform: scale(1.05);
-  }
+  box-shadow: 0 30px 70px rgba(255, 128, 170, 0.45);
 }
 
 .playground {
   width: min(960px, 100%);
   display: grid;
-  gap: 1.8rem;
+  gap: clamp(1.8rem, 4vw, 2.8rem);
+  position: relative;
+}
+
+.playground::before {
+  content: "";
+  position: absolute;
+  inset: -20% -35% auto -35%;
+  height: 120%;
+  background: radial-gradient(circle, rgba(255, 214, 232, 0.25) 0%, rgba(255, 255, 255, 0) 70%);
+  z-index: 0;
 }
 
 .playHeader {
@@ -260,53 +302,113 @@
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 1.2rem;
+  padding: 1.4rem 1.75rem;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.75);
+  border: 1px solid rgba(255, 149, 190, 0.25);
+  box-shadow: 0 20px 60px rgba(20, 30, 55, 0.14);
+  backdrop-filter: blur(18px);
+  position: relative;
+  z-index: 1;
 }
 
 .badges {
   display: inline-flex;
   flex-wrap: wrap;
-  gap: 0.65rem;
+  gap: 0.75rem;
 }
 
 .tierBadge,
 .infoBadge {
   display: inline-flex;
   align-items: center;
-  padding: 0.55rem 1rem;
+  gap: 0.35rem;
+  padding: 0.55rem 1.2rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.85);
-  box-shadow: 0 12px 30px rgba(20, 30, 55, 0.14);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(255, 214, 232, 0.55));
+  box-shadow: 0 12px 30px rgba(255, 149, 190, 0.22);
   font-weight: 600;
-  color: #b10059;
+  color: #ff5e86;
+}
+
+.infoBadge {
+  color: #1f2937;
 }
 
 .playBody {
+  position: relative;
   display: flex;
   justify-content: center;
+  align-items: center;
+  padding: clamp(1.2rem, 4vw, 2.2rem);
+  min-height: clamp(440px, 70vh, 560px);
+  isolation: isolate;
+}
+
+.playBody::before,
+.playBody::after {
+  content: "";
+  position: absolute;
+  width: clamp(260px, 58vw, 380px);
+  height: clamp(340px, 62vh, 520px);
+  border-radius: 36px;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.65), rgba(255, 210, 232, 0.45));
+  box-shadow: 0 30px 70px rgba(255, 149, 190, 0.28);
+  z-index: 0;
+}
+
+.playBody::before {
+  top: 50%;
+  left: 50%;
+  transform: translate(-55%, -48%) rotate(-12deg);
+  opacity: 0.55;
+}
+
+.playBody::after {
+  top: 50%;
+  left: 50%;
+  transform: translate(-45%, -52%) rotate(12deg);
+  opacity: 0.4;
 }
 
 .productCard {
   position: relative;
   width: min(420px, 100%);
-  border-radius: 32px;
-  background: rgba(255, 255, 255, 0.92);
-  box-shadow: 0 35px 80px rgba(20, 30, 55, 0.18);
+  border-radius: 38px;
+  background: linear-gradient(165deg, rgba(255, 255, 255, 0.95), rgba(255, 214, 232, 0.86));
+  border: 1px solid rgba(255, 149, 190, 0.3);
+  box-shadow: 0 35px 90px rgba(255, 149, 190, 0.32);
   overflow: hidden;
   display: grid;
-  gap: 1.1rem;
-  padding-bottom: 1.25rem;
+  gap: 1.2rem;
+  padding-bottom: 1.8rem;
   transition: transform 0.2s ease;
+  isolation: isolate;
+  z-index: 1;
+}
+
+.productCard::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.45), rgba(255, 255, 255, 0) 55%);
+  z-index: 0;
+}
+
+.productCard > * {
+  position: relative;
+  z-index: 1;
 }
 
 .cardDisabled {
-  opacity: 0.65;
+  opacity: 0.6;
   pointer-events: none;
 }
 
 .productImageWrap {
   position: relative;
-  aspect-ratio: 1 / 1;
+  aspect-ratio: 1 / 1.1;
   overflow: hidden;
 }
 
@@ -314,59 +416,76 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
+  transform: scale(1.02);
+}
+
+.productImageWrap::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 0 0;
+  height: 45%;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, rgba(255, 214, 232, 0.65) 100%);
 }
 
 .sectorBadge {
   position: absolute;
-  top: 1rem;
-  left: 1rem;
-  padding: 0.4rem 0.8rem;
+  top: 1.4rem;
+  left: 1.4rem;
+  padding: 0.5rem 1.1rem;
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.88);
-  color: #b10059;
+  color: #ff5e86;
   font-weight: 600;
   font-size: 0.85rem;
+  box-shadow: 0 14px 28px rgba(17, 24, 39, 0.18);
 }
 
 .productBody {
-  padding: 0 1.75rem;
+  padding: 0 2.2rem;
   display: grid;
-  gap: 0.65rem;
+  gap: 0.75rem;
+  text-align: left;
 }
 
 .productBody h2 {
   margin: 0;
-  font-size: 1.35rem;
-  color: #b10059;
+  font-size: clamp(1.45rem, 3.4vw, 1.85rem);
+  color: #ff5e86;
 }
 
 .productBody p {
   margin: 0;
   color: rgba(17, 24, 39, 0.7);
-  font-size: 0.95rem;
+  font-size: 0.98rem;
 }
 
 .priceTag {
   font-weight: 700;
-  font-size: 1.25rem;
+  font-size: 1.35rem;
   color: #111827;
 }
 
 .swipeOverlay {
   position: absolute;
-  bottom: 1.4rem;
+  bottom: clamp(1.2rem, 3vw, 1.8rem);
   left: 50%;
   transform: translateX(-50%);
   display: inline-flex;
-  gap: 1.4rem;
+  gap: clamp(1rem, 4vw, 1.6rem);
+  padding: 0.7rem 1.1rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.78);
+  backdrop-filter: blur(14px);
+  box-shadow: 0 24px 55px rgba(255, 149, 190, 0.3);
+  z-index: 2;
 }
 
 .controlButton {
-  width: 72px;
-  height: 72px;
+  width: 68px;
+  height: 68px;
   border-radius: 50%;
   border: none;
-  font-size: 1.8rem;
+  font-size: 1.9rem;
   display: grid;
   place-items: center;
   color: white;
@@ -384,14 +503,15 @@
 .controlButton:hover:not(:disabled),
 .controlButton:focus-visible:not(:disabled) {
   transform: translateY(-3px);
+  box-shadow: 0 26px 58px rgba(20, 30, 55, 0.32);
 }
 
 .reject {
-  background: linear-gradient(135deg, #ff6b7b 0%, #ff416d 100%);
+  background: linear-gradient(135deg, #ff6b88 0%, #ff3d6b 100%);
 }
 
 .keep {
-  background: linear-gradient(135deg, #3ac7a5 0%, #1abc9c 100%);
+  background: linear-gradient(135deg, #3ad0b8 0%, #37a7ff 100%);
 }
 
 .summaryList {
@@ -409,16 +529,16 @@
   display: flex;
   justify-content: space-between;
   gap: 1rem;
-  padding: 0.75rem 1rem;
-  border-radius: 16px;
-  background: rgba(255, 255, 255, 0.85);
-  box-shadow: inset 0 0 0 1px rgba(177, 0, 89, 0.08);
+  padding: 0.85rem 1.1rem;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: inset 0 0 0 1px rgba(255, 149, 190, 0.16);
 }
 
 .summaryList h3 {
   margin: 0 0 0.35rem;
   font-size: 1rem;
-  color: #b10059;
+  color: #ff5e86;
 }
 
 .summaryList p {
@@ -434,24 +554,26 @@
 
 .summaryActions {
   display: flex;
+  flex-wrap: wrap;
   justify-content: center;
   gap: 1rem;
 }
 
-.summaryActions button {
+.summaryActions button:not(.glowButton) {
   border-radius: 999px;
   padding: 0.75rem 1.6rem;
   border: none;
   font-weight: 600;
   cursor: pointer;
-  background: rgba(177, 0, 89, 0.12);
-  color: #b10059;
-  transition: transform 0.2s ease;
+  background: rgba(255, 149, 190, 0.2);
+  color: #ff5e86;
+  transition: transform 0.2s ease, background 0.2s ease;
 }
 
-.summaryActions button:hover:not(:disabled),
-.summaryActions button:focus-visible:not(:disabled) {
+.summaryActions button:not(.glowButton):hover:not(:disabled),
+.summaryActions button:not(.glowButton):focus-visible:not(:disabled) {
   transform: translateY(-2px);
+  background: rgba(255, 149, 190, 0.28);
 }
 
 .summaryActions button:disabled {
@@ -462,7 +584,7 @@
 .savings {
   margin: 0;
   font-weight: 600;
-  color: #b10059;
+  color: #ff5e86;
 }
 
 .attempts {
@@ -474,7 +596,7 @@
 .error {
   margin: 0;
   font-weight: 600;
-  color: #ff416d;
+  color: #ff3d6b;
 }
 
 .form {
@@ -485,7 +607,7 @@
 
 .formRow {
   display: grid;
-  gap: 0.45rem;
+  gap: 0.5rem;
 }
 
 .formGroup {
@@ -495,17 +617,18 @@
 
 .form label {
   font-weight: 600;
-  color: #b10059;
+  color: #ff5e86;
 }
 
 .form input,
 .form textarea {
   border-radius: 14px;
-  border: 1px solid rgba(177, 0, 89, 0.18);
-  padding: 0.75rem 0.9rem;
+  border: 1px solid rgba(255, 149, 190, 0.26);
+  padding: 0.8rem 0.95rem;
   font: inherit;
   background: rgba(255, 255, 255, 0.96);
   resize: vertical;
+  box-shadow: inset 0 1px 2px rgba(17, 24, 39, 0.06);
 }
 
 .form textarea {
@@ -514,22 +637,23 @@
 
 .form input:focus-visible,
 .form textarea:focus-visible {
-  outline: 2px solid rgba(177, 0, 89, 0.3);
-  border-color: rgba(177, 0, 89, 0.4);
+  outline: 2px solid rgba(255, 149, 190, 0.35);
+  border-color: rgba(255, 149, 190, 0.45);
 }
 
 .successBox {
-  padding: 1.2rem 1.4rem;
-  border-radius: 18px;
-  background: rgba(58, 199, 165, 0.15);
-  color: #145246;
+  padding: 1.3rem 1.5rem;
+  border-radius: 20px;
+  background: rgba(58, 199, 165, 0.18);
+  color: #125f4f;
   font-weight: 500;
 }
 
 @media (max-width: 960px) {
-  .swipeOverlay {
-    gap: 1rem;
-    bottom: 1rem;
+  .playBody::before,
+  .playBody::after {
+    width: clamp(240px, 70vw, 340px);
+    height: clamp(320px, 68vh, 460px);
   }
 
   .controlButton {
@@ -540,7 +664,7 @@
 
 @media (max-width: 720px) {
   .page {
-    padding: 2rem 1rem 3rem;
+    padding: 2rem 1.2rem 3rem;
   }
 
   .toast {
@@ -549,11 +673,19 @@
   }
 
   .playground {
-    gap: 1.4rem;
+    gap: 1.6rem;
+  }
+
+  .playHeader {
+    padding: 1.1rem 1.3rem;
+  }
+
+  .playBody {
+    min-height: clamp(420px, 80vh, 520px);
   }
 
   .productBody {
-    padding: 0 1.25rem;
+    padding: 0 1.6rem;
   }
 
   .summaryList {
@@ -563,15 +695,32 @@
 
 @media (max-width: 520px) {
   .stepCard {
-    padding: 1.75rem 1.4rem;
+    padding: 1.85rem 1.5rem;
   }
 
-  .ticketCard button {
-    flex-direction: column;
-    align-items: flex-start;
+  .ticketBody button {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .playBody::before,
+  .playBody::after {
+    display: none;
   }
 
   .productCard {
-    padding-bottom: 0;
+    padding-bottom: 1.4rem;
+    border-radius: 32px;
+  }
+
+  .swipeOverlay {
+    gap: 1rem;
+    padding: 0.65rem 0.9rem;
+  }
+
+  .controlButton {
+    width: 58px;
+    height: 58px;
+    font-size: 1.6rem;
   }
 }

--- a/app/play/page.tsx
+++ b/app/play/page.tsx
@@ -515,7 +515,7 @@ export default function PlayPage() {
         <div className={styles.stepCard}>
           <h1 className={styles.introTitle}>All You Can Makeup</h1>
           <p className={styles.introCopy}>
-            Il tuo limite sarà solo il tempo: tutto quello che metterai nel carrello sarà tuo!
+            Il tuo limite è solo il tempo, tutto quello che riuscirai a mettere nel carrello sarà tuo.
           </p>
           <button type="button" className={styles.glowButton} onClick={() => setStage("ticket")}>GIOCA</button>
         </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -13,10 +13,36 @@
   margin: 0;
   min-height: 100vh;
   font-family: "SF Pro Display", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
-  background: radial-gradient(circle at top, #ffeefd 0%, #f7faff 45%, #ffffff 100%);
+  background: radial-gradient(circle at 10% 0%, rgba(255, 205, 234, 0.55) 0%, rgba(255, 255, 255, 0) 45%),
+    radial-gradient(circle at 90% 5%, rgba(182, 203, 255, 0.5) 0%, rgba(255, 255, 255, 0) 52%),
+    linear-gradient(160deg, #fff9fc 0%, #f6f9ff 40%, #ffffff 100%);
   color: #121314;
   display: flex;
   flex-direction: column;
+  position: relative;
+  overflow-x: hidden;
+}
+
+.app-body::before,
+.app-body::after {
+  content: "";
+  position: fixed;
+  z-index: 0;
+  width: clamp(320px, 45vw, 540px);
+  height: clamp(320px, 45vw, 540px);
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 149, 190, 0.18) 0%, rgba(255, 255, 255, 0) 70%);
+  pointer-events: none;
+}
+
+.app-body::before {
+  top: -140px;
+  left: -160px;
+}
+
+.app-body::after {
+  bottom: -180px;
+  right: -120px;
 }
 
 .app-header {
@@ -27,9 +53,10 @@
   align-items: center;
   justify-content: space-between;
   padding: clamp(0.75rem, 2vw, 1.5rem) clamp(1rem, 4vw, 3rem);
-  backdrop-filter: blur(12px);
-  background: rgba(255, 255, 255, 0.82);
-  border-bottom: 1px solid rgba(15, 23, 42, 0.06);
+  backdrop-filter: blur(18px);
+  background: rgba(255, 255, 255, 0.68);
+  border-bottom: 1px solid rgba(255, 182, 206, 0.35);
+  box-shadow: 0 10px 32px rgba(255, 170, 202, 0.18);
 }
 
 .app-header img {
@@ -53,26 +80,30 @@
 .app-nav a {
   color: inherit;
   text-decoration: none;
-  padding: 0.4rem 0.5rem;
+  padding: 0.5rem 1.1rem;
   border-radius: 999px;
-  transition: background 0.2s ease, color 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  background: rgba(255, 255, 255, 0.3);
+  box-shadow: inset 0 0 0 1px rgba(255, 149, 190, 0.28);
 }
 
 .app-nav a:hover,
 .app-nav a:focus-visible {
-  background: rgba(255, 119, 176, 0.15);
-  color: #b10059;
+  transform: translateY(-2px);
+  box-shadow: inset 0 0 0 1px rgba(255, 149, 190, 0.4), 0 12px 22px rgba(255, 149, 190, 0.25);
   outline: none;
 }
 
 .app-main {
-  width: min(1080px, 100%);
+  width: min(1120px, 100%);
   margin: 0 auto;
   flex: 1;
   padding: clamp(1.5rem, 4vw, 3.5rem) clamp(1.25rem, 4vw, 3rem) clamp(4rem, 6vw, 5rem);
   display: flex;
   flex-direction: column;
   gap: clamp(1.5rem, 3vw, 3rem);
+  position: relative;
+  z-index: 1;
 }
 
 a {
@@ -95,15 +126,15 @@ button {
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
-  padding: 0.75rem 1.25rem;
+  padding: 0.85rem 1.6rem;
   border-radius: 999px;
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  background: linear-gradient(135deg, #ff7cb4 0%, #ff9a8d 100%);
+  border: none;
+  background: linear-gradient(135deg, #ff7cb4 0%, #ff928d 45%, #ffce8d 100%);
   color: white;
   font-weight: 600;
   cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
-  box-shadow: 0 10px 25px rgba(255, 122, 180, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 18px 35px rgba(255, 140, 180, 0.35);
 }
 
 .btn:disabled {
@@ -113,18 +144,18 @@ button {
 }
 
 .btn:hover:not(:disabled) {
-  transform: translateY(-1px);
+  transform: translateY(-3px);
+  box-shadow: 0 24px 45px rgba(255, 140, 180, 0.4);
 }
 
 .btn.secondary {
-  background: white;
+  background: rgba(255, 255, 255, 0.85);
   color: #b10059;
-  border-color: rgba(177, 0, 89, 0.25);
-  box-shadow: none;
+  box-shadow: inset 0 0 0 1px rgba(177, 0, 89, 0.22);
 }
 
 .btn.secondary:hover:not(:disabled) {
-  background: rgba(177, 0, 89, 0.08);
+  background: rgba(177, 0, 89, 0.12);
 }
 
 /* Utility classes used nelle impostazioni */


### PR DESCRIPTION
## Summary
- redirect the root route directly to the play intro screen so the "GIOCA" CTA appears first
- refresh the global chrome with new gradients, glassmorphism header, and updated primary buttons
- restyle the play flow cards, timers, and controls to mirror the requested swipe app aesthetic

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cabcabd1ac8323872babcade39a018